### PR TITLE
Fix migration script price normalization for production data

### DIFF
--- a/lib/tasks/production_migration.rake
+++ b/lib/tasks/production_migration.rake
@@ -805,12 +805,9 @@ namespace :migrate do
       # Handle dollar amounts like "$25.00" or "25.00"
       cleaned = price_value.gsub(/[$,]/, "")
       (cleaned.to_f * 100).to_i
-    when Integer
-      # Production data stores prices as dollars (not cents), so convert to cents
-      price_value * 100
-    when Float
-      # Convert dollars to cents
-      (price_value * 100).to_i
+    when Integer, Float
+      # Production data stores prices as dollars, convert to cents
+      (price_value.to_f * 100).to_i
     else
       nil
     end


### PR DESCRIPTION
## Summary
- Fix `normalize_price` function in migration script to properly handle production dollar values
- Consolidate Integer and Float price conversion logic for consistency  
- Ensure production prices (stored as dollars) are correctly converted to cents

## Test plan
- [x] Updated migration script price normalization logic
- [x] Reset database and cleared storage files
- [x] Successfully ran full migration importing 773 posters and 374 user collections
- [x] Verified price conversion: $125.00 production → 12500 cents → displays as $125.00
- [x] All tests passing (327 examples, 0 failures)
- [x] Clean linting (0 offenses) and security scan (0 warnings)

## Changes Made
- Updated `lib/tasks/production_migration.rake` normalize_price function
- Combined Integer/Float cases with consistent `.to_f * 100` conversion
- Removed redundant logic while maintaining correct dollar-to-cents conversion

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)