### PR TITLE
Fix poster image cropping on detail pages

### DIFF
--- a/app/views/posters/show.html.erb
+++ b/app/views/posters/show.html.erb
@@ -52,12 +52,12 @@
             
             <!-- Blurred placeholder (loads instantly) -->
             <img data-progressive-image-target="placeholder" 
-                 class="progressive-placeholder absolute inset-0 w-full h-full object-cover" 
+                 class="progressive-placeholder absolute inset-0 w-full h-full object-contain" 
                  alt="<%= @poster.name %> placeholder" />
             
             <!-- Detail image (loads progressively) -->
             <img data-progressive-image-target="mainImage" 
-                 class="progressive-main-image absolute inset-0 w-full h-full object-cover loading" 
+                 class="progressive-main-image absolute inset-0 w-full h-full object-contain loading" 
                  alt="<%= @poster.name %>" />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fixes poster image cropping issue on detail pages where images were cut off at top/bottom
- Changes CSS from `object-cover` to `object-contain` for both placeholder and main images
- Maintains 3:4 aspect ratio container for consistent layout while showing complete posters

## Changes Made
- Updated `app/views/posters/show.html.erb` lines 55 and 60
- Changed `object-cover` to `object-contain` for progressive image loading

## Test Plan
- [x] Visit http://localhost:3000/posters/vivien-2016 to verify complete poster is visible
- [x] Verify other posters still display properly in 3:4 containers
- [x] Run full test suite: 345+ tests passing
- [x] Linting: 0 offenses detected
- [x] Security scan: 0 warnings

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)