### PR TITLE
Add AWS credentials to Kamal secrets configuration

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -3,8 +3,12 @@
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
 
 # Extract secrets from 1Password
-SECRETS=$(kamal secrets fetch --adapter 1password --account EDM2HXLJBJBWLAD4MSSMVVEYVQ --from "Kamal-Deployment-Secrets/the-art-exchange-production" RAILS_MASTER_KEY DATABASE_URL KAMAL_REGISTRY_PASSWORD ANTHROPIC_API_KEY)
+SECRETS=$(kamal secrets fetch --adapter 1password --account EDM2HXLJBJBWLAD4MSSMVVEYVQ --from "Kamal-Deployment-Secrets/the-art-exchange-production" RAILS_MASTER_KEY DATABASE_URL KAMAL_REGISTRY_PASSWORD ANTHROPIC_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_S3_BUCKET AWS_REGION)
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
 DATABASE_URL=$(kamal secrets extract DATABASE_URL ${SECRETS})
 KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
 ANTHROPIC_API_KEY=$(kamal secrets extract ANTHROPIC_API_KEY ${SECRETS})
+AWS_ACCESS_KEY_ID=$(kamal secrets extract AWS_ACCESS_KEY_ID ${SECRETS})
+AWS_SECRET_ACCESS_KEY=$(kamal secrets extract AWS_SECRET_ACCESS_KEY ${SECRETS})
+AWS_S3_BUCKET=$(kamal secrets extract AWS_S3_BUCKET ${SECRETS})
+AWS_REGION=$(kamal secrets extract AWS_REGION ${SECRETS})


### PR DESCRIPTION
## Summary
- Updates `.kamal/secrets` to include AWS S3 credentials from 1Password
- Required to complete S3 storage deployment configuration

## Changes Made
- Added AWS_ACCESS_KEY_ID to secrets fetch and extract
- Added AWS_SECRET_ACCESS_KEY to secrets fetch and extract  
- Added AWS_S3_BUCKET to secrets fetch and extract
- Added AWS_REGION to secrets fetch and extract

## Test Plan
- [x] File syntax is correct
- [ ] Deploy and verify AWS credentials are properly injected

Completes the S3 storage setup from PR #60.

🤖 Generated with [Claude Code](https://claude.ai/code)