### PR TITLE
Fix migration validation error for terms acceptance

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,9 +24,9 @@ class User < ApplicationRecord
   validates :twitter_handle, format: { with: /\A[a-zA-Z0-9_]{1,15}\z/ }, allow_blank: true
 
   # Terms of Service acceptance validation
-  validates :terms_accepted_at, presence: { message: "You must accept the Terms of Service to create an account" }, on: :create
+  validates :terms_accepted_at, presence: { message: "You must accept the Terms of Service to create an account" }, on: :create, unless: -> { validation_context == :migration }
   validates :terms_version, presence: true, if: :terms_accepted_at?
-  validate :terms_acceptance_is_recent, on: :create
+  validate :terms_acceptance_is_recent, on: :create, unless: -> { validation_context == :migration }
 
   # Optional password validation
   validates :password, length: {

--- a/lib/tasks/production_migration.rake
+++ b/lib/tasks/production_migration.rake
@@ -292,7 +292,7 @@ namespace :migrate do
           end
 
           begin
-            User.create!(
+            user = User.new(
               id: prod_user["id"],
               email: prod_user["email"],
               first_name: prod_user["first_name"],
@@ -304,6 +304,7 @@ namespace :migrate do
               terms_version: "legacy-import" # Mark as legacy users for later re-acceptance
               # Note: Skip encrypted_password - users will need to reset passwords
             )
+            user.save!(context: :migration)
             imported_count += 1
             puts "  ✅ Imported user #{prod_user['id']}: #{prod_user['email']}" if imported_count % 50 == 0
           rescue ActiveRecord::RecordInvalid => e


### PR DESCRIPTION
## Summary
- Fixes validation error during user migration: "terms accepted at acceptance must be recent (within the last hour)"
- Allows importing legacy users with old terms_accepted_at dates while preserving normal validation for new user creation

## Changes
- Added validation context exclusion for `:migration` in User model terms acceptance validations
- Updated migration script to use `save\!(context: :migration)` during user import
- Preserves all existing validation behavior for normal user registration

## Test plan
- [x] Tested migration with legacy user data - no validation errors
- [x] Verified normal user creation still requires recent terms acceptance
- [x] Confirmed imported users are properly prompted to accept updated terms

🤖 Generated with [Claude Code](https://claude.ai/code)