### PR TITLE
Fix production rate limiting issues - remove general throttling

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -27,10 +27,9 @@ class Rack::Attack
     end
   end
 
-  # General request throttling
-  throttle("req/ip", limit: 300, period: 5.minutes) do |req|
-    req.ip
-  end
+  # General request throttling disabled for browsing-heavy poster app
+  # Auth-specific rate limits above are sufficient for security
+  # Unlimited browsing allows infinite scroll, AJAX, prefetch, and image loading
 
   # Custom response for throttled requests
   self.throttled_responder = lambda do |request|


### PR DESCRIPTION
## Problem

Production users are experiencing "Rate limit exceeded" errors during normal browsing due to overly restrictive Rack::Attack configuration.

The previous general rate limit of **300 requests per 5 minutes (60/min)** is insufficient for a modern poster discovery application with:

- **Infinite scrolling** loading 40+ posters per scroll action
- **Multiple image requests** per poster (thumbnails, grid views, detail images)
- **AJAX search and filtering** with real-time updates
- **Turbo/Stimulus** page transitions and prefetch requests
- **Corporate/NAT IPs** with multiple users sharing the same IP address

## Solution

- ✅ **Remove general IP-based rate limiting** entirely
- ✅ **Maintain authentication security** with targeted rate limits:
  - 5 auth attempts per hour per IP
  - 3 OTP requests per hour per email  
  - 3 password resets per hour per email

## Benefits

- **Eliminates browsing interruptions** - users can scroll and browse freely
- **Maintains security** - authentication endpoints remain protected
- **Improves user experience** - no artificial barriers to poster discovery
- **Supports modern web patterns** - infinite scroll, AJAX, prefetch work properly

## Testing

- [x] **Authentication limits verified** - auth endpoints remain protected
- [x] **General browsing unrestricted** - infinite scroll works without limits
- [x] **Image loading improved** - multiple variants load without throttling

## Deployment Impact

This is a **low-risk, high-impact fix** that:
- Immediately resolves user-facing rate limit errors
- Maintains all security protections for sensitive endpoints
- Requires no database changes or migrations
- Takes effect immediately upon deployment

**Priority: High** - This directly affects user experience in production.

🤖 Generated with [Claude Code](https://claude.ai/code)